### PR TITLE
fix: Fix build error with latest bevy_input_actionmap

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -4,7 +4,7 @@ use bevy_inspector_egui::WorldInspectorParams;
 
 use crate::{ui::EditorMenuEvent, EditorSettings};
 
-#[derive(Hash, PartialEq, Eq, Clone)]
+#[derive(Hash, PartialEq, Eq, Clone, Debug)]
 pub enum EditorAction {
     ToggleWorldInspector,
     ToggleClickToInspect,


### PR DESCRIPTION
bevy_input_actionmap had a breaking change and now requires actions to
implement the Debug trait.

See: https://github.com/lightsoutgames/bevy_input_actionmap/commit/1d8a96c2a6b75a684b3931b404055d3cce9a01b8