### PR TITLE
Prevent pressing E while typing in a field from closing the editor

### DIFF
--- a/crates/bevy_editor_pls/src/controls.rs
+++ b/crates/bevy_editor_pls/src/controls.rs
@@ -15,6 +15,7 @@ pub enum UserInput {
 pub enum BindingCondition {
     InViewport(bool),
     EditorActive(bool),
+    ListeningForText(bool),
 }
 
 impl BindingCondition {
@@ -30,6 +31,7 @@ impl BindingCondition {
                 }
             }
             BindingCondition::EditorActive(editor_active) => editor_active == editor_state.active,
+            BindingCondition::ListeningForText(listening) => listening == editor_state.listening_for_text,
         }
     }
 }
@@ -41,6 +43,8 @@ impl std::fmt::Display for BindingCondition {
             BindingCondition::InViewport(false) => "mouse not in viewport",
             BindingCondition::EditorActive(true) => "editor is active",
             BindingCondition::EditorActive(false) => "editor is not active",
+            BindingCondition::ListeningForText(true) => "a ui field is listening for text",
+            BindingCondition::ListeningForText(false) => "no ui fields are listening for text",
         };
         f.write_str(str)
     }
@@ -211,7 +215,7 @@ impl EditorControls {
             Action::PlayPauseEditor,
             Binding {
                 input: UserInput::Single(Button::Keyboard(KeyCode::E)),
-                conditions: Vec::new(),
+                conditions: vec![BindingCondition::ListeningForText(false)],
             },
         );
 

--- a/crates/bevy_editor_pls_core/src/editor.rs
+++ b/crates/bevy_editor_pls_core/src/editor.rs
@@ -42,6 +42,7 @@ pub struct EditorState {
     pub pointer_in_viewport: bool,
     pub pointer_on_floating_window: bool,
     pub viewport: egui::Rect,
+    pub listening_for_text: bool,
 }
 
 impl EditorState {
@@ -57,6 +58,7 @@ impl Default for EditorState {
             pointer_in_viewport: false,
             pointer_on_floating_window: false,
             viewport: egui::Rect::NOTHING,
+            listening_for_text: false,
         }
     }
 }
@@ -298,6 +300,8 @@ impl Editor {
                 .expand(-ctx.style().interaction.resize_grab_radius_side)
                 .contains(interact_pos);
         };
+
+        editor_state.listening_for_text = ctx.wants_keyboard_input();
     }
 
     fn editor_menu_bar(


### PR DESCRIPTION
This kept annoying me while saving scenes/implementing a component search so I fixed it real quick.