### PR TITLE
Added ability to focus camera on selected entity

### DIFF
--- a/crates/bevy_editor_pls/src/controls.rs
+++ b/crates/bevy_editor_pls/src/controls.rs
@@ -212,7 +212,6 @@ pub fn editor_controls_system(
         &editor_state,
     ) {
         editor_events.send(EditorEvent::FocusSelected);
-        println!("Focus selected");
     }
 }
 

--- a/crates/bevy_editor_pls/src/controls.rs
+++ b/crates/bevy_editor_pls/src/controls.rs
@@ -123,6 +123,7 @@ pub enum Action {
     PlayPauseEditor,
     SelectMesh,
     PauseUnpauseTime,
+    FocusSelected,
 }
 
 impl std::fmt::Display for Action {
@@ -131,6 +132,7 @@ impl std::fmt::Display for Action {
             Action::PlayPauseEditor => write!(f, "Play/Pause editor"),
             Action::SelectMesh => write!(f, "Select mesh to inspect"),
             Action::PauseUnpauseTime => write!(f, "Pause/Unpause time"),
+            Action::FocusSelected => write!(f, "Focus Selected Entity"),
         }
     }
 }
@@ -202,6 +204,16 @@ pub fn editor_controls_system(
             default_window.pause_time = !default_window.pause_time;
         }
     }
+
+    if controls.just_pressed(
+        Action::FocusSelected,
+        &keyboard_input,
+        &mouse_input,
+        &editor_state,
+    ) {
+        editor_events.send(EditorEvent::FocusSelected);
+        println!("Focus selected");
+    }
 }
 
 impl EditorControls {
@@ -248,6 +260,14 @@ impl EditorControls {
             Binding {
                 input: UserInput::Single(Button::Keyboard(KeyCode::E)),
                 conditions: vec![BindingCondition::ListeningForText(false)],
+            },
+        );
+
+        controls.insert(
+            Action::FocusSelected,
+            Binding {
+                input: UserInput::Single(Button::Keyboard(KeyCode::F)),
+                conditions: vec![BindingCondition::EditorActive(true)],
             },
         );
 
@@ -320,6 +340,7 @@ impl EditorWindow for ControlsWindow {
             Action::PlayPauseEditor,
             Action::PauseUnpauseTime,
             Action::SelectMesh,
+            Action::FocusSelected,
         ] {
             ui.label(egui::RichText::new(action.to_string()).strong());
             let bindings = controls.get(action);

--- a/crates/bevy_editor_pls_core/src/editor.rs
+++ b/crates/bevy_editor_pls_core/src/editor.rs
@@ -36,6 +36,7 @@ impl Plugin for EditorPlugin {
 #[non_exhaustive]
 pub enum EditorEvent {
     Toggle { now_active: bool },
+    FocusSelected,
 }
 
 pub struct EditorState {

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -339,7 +339,7 @@ fn focus_selected(
                 return;
             }
 
-            let desired_translation: Vec3 = hierarchy
+            let average_translation: Vec3 = hierarchy
                 .selected
                 .iter()
                 .filter_map(|e| {
@@ -348,10 +348,12 @@ fn focus_selected(
                         .find(|(s_e, _)| e == *s_e)
                         .map_or(None, |(_, tf)| Some(tf.translation))
                 })
-                .fold(Vec3::ZERO.clone(), |acc, x| acc + x)
+                .fold(Vec3::ZERO, |acc, x| acc + x)
                 / hierarchy.selected.len() as f32;
 
-            query.single_mut().translation = desired_translation;
+            let mut camera_tf = query.single_mut();
+            camera_tf.translation =
+                average_translation + camera_tf.rotation.mul_vec3(Vec3::Z) * 10.0;
         }
     }
 }

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -17,6 +17,8 @@ use bevy_inspector_egui::egui;
 
 use crate::hierarchy::{HideInEditor, HierarchyWindow};
 
+use self::camera_3d_panorbit::PanOrbitCamera;
+
 // Present on all editor cameras
 #[derive(Component)]
 pub struct EditorCamera;
@@ -327,7 +329,7 @@ fn toggle_editor_cam(
 
 fn focus_selected(
     mut editor_events: EventReader<EditorEvent>,
-    mut query: Query<&mut Transform, With<ActiveEditorCamera>>,
+    mut query: Query<(&mut Transform, Option<&mut PanOrbitCamera>), With<ActiveEditorCamera>>,
     selected_query: Query<(Entity, &Transform), Without<ActiveEditorCamera>>,
     editor: Res<Editor>,
 ) {
@@ -351,9 +353,16 @@ fn focus_selected(
                 .fold(Vec3::ZERO, |acc, x| acc + x)
                 / hierarchy.selected.len() as f32;
 
-            let mut camera_tf = query.single_mut();
+            let distance_to_cam = 10.0;
+
+            let (mut camera_tf, pan_orbit_cam) = query.single_mut();
             camera_tf.translation =
-                average_translation + camera_tf.rotation.mul_vec3(Vec3::Z) * 10.0;
+                average_translation + camera_tf.rotation.mul_vec3(Vec3::Z) * distance_to_cam;
+
+            if let Some(mut pan_orbit_cam) = pan_orbit_cam {
+                pan_orbit_cam.focus = average_translation;
+                pan_orbit_cam.radius = distance_to_cam;
+            }
         }
     }
 }


### PR DESCRIPTION
One of the first features when trying this plugin out was the ability to focus on selected entities, and that is the feature this PR adds. It has been tested in all camera modes, and works as I would expect in all of them.
The default hotkey is `F`.

This is the first time I've made a PR, so let me know if there's something else I should to do :) This is a wonderful plugin and I would love to contribute more to it!