### PR TITLE
Fix focus_selected focusing on wrong location

### DIFF
--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -339,7 +339,7 @@ fn focus_selected(
         With<ActiveEditorCamera>,
     >,
     selected_query: Query<
-        (Entity, &Transform, Option<&Aabb>, Option<&Sprite>),
+        (Entity, &GlobalTransform, Option<&Aabb>, Option<&Sprite>),
         Without<ActiveEditorCamera>,
     >,
     editor: Res<Editor>,


### PR DESCRIPTION
It was using the entity's local transform to set the camera location. This meant if your entity had a parent that was moved, it would not include the parent's transform in the location set for the camera. This commonly manifested as centering on the world origin instead of the selected entity. (Because it's common for an imported mesh to be
parented to a root node.)

This changes it to query the GlobalTransform component instead which is updated by Bevy to include all parent transforms. See https://bevy-cheatbook.github.io/features/transforms.html for more info.

Thanks @pramberg for adding this functionality! I was also sorely missing it.