### PR TITLE
Fix focus selected in hierarchy

### DIFF
--- a/crates/bevy_editor_pls/Cargo.toml
+++ b/crates/bevy_editor_pls/Cargo.toml
@@ -19,4 +19,5 @@ bevy_editor_pls_default_windows = { path = "../bevy_editor_pls_default_windows",
 bevy = { version = "0.7", default-features = false, features = [
     "bevy_winit",
     "x11",
+    "png",
 ] }

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -412,11 +412,8 @@ fn focus_selected(
             }
 
             let len = hierarchy.selected.len();
-            info!(
-                "Focused on {} {}",
-                len,
-                if len == 1 { "entity" } else { "entities" }
-            );
+            let noun = if len == 1 { "entity" } else { "entities" };
+            info!("Focused on {} {}", len, noun);
         }
     }
 }

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -339,7 +339,7 @@ fn focus_selected(
         With<ActiveEditorCamera>,
     >,
     selected_query: Query<
-        (Entity, &Transform, Option<&Aabb>, Option<&Sprite>),
+        (Entity, &GlobalTransform, Option<&Aabb>, Option<&Sprite>),
         Without<ActiveEditorCamera>,
     >,
     editor: Res<Editor>,

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -339,7 +339,7 @@ fn focus_selected(
         With<ActiveEditorCamera>,
     >,
     selected_query: Query<
-        (Entity, &GlobalTransform, Option<&Aabb>, Option<&Sprite>),
+        (&GlobalTransform, Option<&Aabb>, Option<&Sprite>),
         Without<ActiveEditorCamera>,
     >,
     editor: Res<Editor>,
@@ -363,7 +363,7 @@ fn focus_selected(
             .filter_map(|selected_e| {
                 selected_query
                     .get(selected_e)
-                    .map(|(_, &tf, bounds, sprite)| {
+                    .map(|(&tf, bounds, sprite)| {
                         let default_value = (tf.translation, tf.translation);
                         let sprite_size = sprite
                             .map(|s| s.custom_size.unwrap_or(Vec2::ONE))

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -361,21 +361,19 @@ fn focus_selected(
                     selected_query
                         .iter()
                         .find(|(query_e, _, _, _)| selected_e == *query_e)
-                        .map(|(_, tf, bounds, sprite)| {
-                            let apply_tf = |v: Vec3| v * tf.scale + tf.translation;
-
+                        .map(|(_, &tf, bounds, sprite)| {
                             let default_value = (tf.translation, tf.translation);
                             let sprite_size = sprite
                                 .map(|s| s.custom_size.unwrap_or(Vec2::ONE))
                                 .map_or(default_value, |sprite_size| {
                                     (
-                                        apply_tf((sprite_size * -0.5, 0.0).into()),
-                                        apply_tf((sprite_size * 0.5, 0.0).into()),
+                                        tf * Vec3::from((sprite_size * -0.5, 0.0)),
+                                        tf * Vec3::from((sprite_size * 0.5, 0.0)),
                                     )
                                 });
 
                             bounds.map_or(sprite_size, |bounds| {
-                                (apply_tf(bounds.min().into()), apply_tf(bounds.max().into()))
+                                (tf * Vec3::from(bounds.min()), tf * Vec3::from(bounds.max()))
                             })
                         })
                 })
@@ -414,7 +412,11 @@ fn focus_selected(
             }
 
             let len = hierarchy.selected.len();
-            info!("Focused on {} {}", len, if len == 1 { "entity" } else { "entities" } );
+            info!(
+                "Focused on {} {}",
+                len,
+                if len == 1 { "entity" } else { "entities" }
+            );
         }
     }
 }


### PR DESCRIPTION
Same as #28, but with some more fixes.
 
`GlobalTransform` is now used to calculate the bounds. The transform is also applied properly to the bounds, so rotations are taken into consideration.

I tested these fixes in the `load_gltf` example, which didn't work properly due to the crate missing the `png` feature.

Worth noting is that I implemented the recursive bounds calculation I mentioned in #28, but I don't think it's desirable. I checked other editors (Unreal and Blender) and neither of those do it. If anyone wants to try it, it's on [this branch](https://github.com/pramberg/bevy_editor_pls/tree/focus-selected-recursive).