### PR TITLE
Add a way to set the default panels

### DIFF
--- a/crates/bevy_editor_pls_core/src/editor.rs
+++ b/crates/bevy_editor_pls_core/src/editor.rs
@@ -105,9 +105,9 @@ struct EditorWindowData {
 }
 
 pub(crate) struct EditorInternalState {
-    left_panel: Option<TypeId>,
-    right_panel: Option<TypeId>,
-    bottom_panel: Option<TypeId>,
+    pub(crate) left_panel: Option<TypeId>,
+    pub(crate) right_panel: Option<TypeId>,
+    pub(crate) bottom_panel: Option<TypeId>,
     pub(crate) floating_windows: Vec<FloatingWindow>,
     active_drag_window: Option<WindowPosition>,
     active_drop_location: Option<DropLocation>,
@@ -152,6 +152,17 @@ enum DropLocation {
 }
 
 impl EditorInternalState {
+    pub(crate) fn new<LFT: EditorWindow, BTTM: EditorWindow, RGHT: EditorWindow>() -> Self {
+        Self {
+            left_panel: Some(TypeId::of::<LFT>()),
+            right_panel: Some(TypeId::of::<RGHT>()),
+            bottom_panel: Some(TypeId::of::<BTTM>()),
+            floating_windows: Vec::new(),
+            next_floating_window_id: 0,
+            active_drag_window: None,
+            active_drop_location: None,
+        }
+    }
     pub(crate) fn next_floating_window_id(&mut self) -> u32 {
         let id = self.next_floating_window_id;
         self.next_floating_window_id += 1;

--- a/crates/bevy_editor_pls_core/src/lib.rs
+++ b/crates/bevy_editor_pls_core/src/lib.rs
@@ -2,6 +2,9 @@ mod drag_and_drop;
 mod editor;
 pub mod editor_window;
 
+use std::any::TypeId;
+
+use editor::EditorInternalState;
 pub use editor::{Editor, EditorEvent, EditorPlugin, EditorState};
 
 use bevy::prelude::App;
@@ -9,13 +12,30 @@ use editor_window::EditorWindow;
 
 pub trait AddEditorWindow {
     fn add_editor_window<W: EditorWindow>(&mut self) -> &mut Self;
+    fn set_default_panels<LFT: EditorWindow, BTTM: EditorWindow, RGHT: EditorWindow>(
+        &mut self,
+    ) -> &mut Self;
 }
 
+const MSG:&str = "Editor resource missing. Make sure to add the `EditorPlugin` before calling `app.add_editor_window`.";
 impl AddEditorWindow for App {
     fn add_editor_window<W: EditorWindow>(&mut self) -> &mut Self {
-        let mut editor = self.world.get_resource_mut::<Editor>().expect("Editor resource missing. Make sure to add the `EditorPlugin` before calling `app.add_editor_window`.");
+        let mut editor = self.world.get_resource_mut::<Editor>().expect(MSG);
         editor.add_window::<W>();
         W::app_setup(self);
+        self
+    }
+    fn set_default_panels<LFT: EditorWindow, BTTM: EditorWindow, RGHT: EditorWindow>(
+        &mut self,
+    ) -> &mut Self {
+        if let Some(mut internal_settings) = self.world.get_resource_mut::<EditorInternalState>() {
+            internal_settings.left_panel = Some(TypeId::of::<LFT>());
+            internal_settings.bottom_panel = Some(TypeId::of::<BTTM>());
+            internal_settings.right_panel = Some(TypeId::of::<RGHT>());
+        } else {
+            let state = EditorInternalState::new::<LFT, BTTM, RGHT>();
+            self.world.insert_resource(state);
+        }
         self
     }
 }


### PR DESCRIPTION
We'd like to be able to set the panels at startup before the editor is
shown. This commit allows this.