### PR TITLE
allow scenes to skip entites in world

### DIFF
--- a/crates/bevy_editor_pls/src/lib.rs
+++ b/crates/bevy_editor_pls/src/lib.rs
@@ -11,6 +11,7 @@ pub use bevy_editor_pls_default_windows as default_windows;
 
 pub mod prelude {
     pub use crate::{AddEditorWindow, EditorPlugin};
+    pub use bevy_editor_pls_default_windows::scenes::NotInScene;
 }
 
 pub struct EditorPlugin;

--- a/crates/bevy_editor_pls_default_windows/src/add.rs
+++ b/crates/bevy_editor_pls_default_windows/src/add.rs
@@ -137,6 +137,8 @@ impl Default for AddWindowState {
 
         state.add("", AddItem::bundle_named::<()>("Empty".into()));
 
+        state.add("NotInScene", AddItem::component::<crate::scenes::NotInScene>());
+
         state.add("Core", AddItem::component::<Name>());
         state.add(
             "Core",

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -1,6 +1,7 @@
 pub mod camera_2d_panzoom;
 pub mod camera_3d_free;
 pub mod camera_3d_panorbit;
+use crate::scenes::NotInScene;
 
 use bevy::utils::HashSet;
 use bevy::{prelude::*, render::primitives::Aabb};
@@ -225,7 +226,8 @@ fn spawn_editor_cameras(mut commands: Commands) {
         .insert(EditorCamera)
         .insert(EditorCamera3dFree)
         .insert(HideInEditor)
-        .insert(Name::new("Editor Camera 3D Free"));
+        .insert(Name::new("Editor Camera 3D Free"))
+        .insert(NotInScene);
 
     commands
         .spawn_bundle(Camera3dBundle {
@@ -246,7 +248,8 @@ fn spawn_editor_cameras(mut commands: Commands) {
         .insert(EditorCamera)
         .insert(EditorCamera3dPanOrbit)
         .insert(HideInEditor)
-        .insert(Name::new("Editor Camera 3D Pan/Orbit"));
+        .insert(Name::new("Editor Camera 3D Pan/Orbit"))
+        .insert(NotInScene);
 
     commands
         .spawn_bundle(Camera2dBundle {
@@ -265,7 +268,8 @@ fn spawn_editor_cameras(mut commands: Commands) {
         .insert(EditorCamera)
         .insert(EditorCamera2dPanZoom)
         .insert(HideInEditor)
-        .insert(Name::new("Editor Camera 2D Pan/Zoom"));
+        .insert(Name::new("Editor Camera 2D Pan/Zoom"))
+        .insert(NotInScene);
 }
 
 fn set_editor_cam_active(

--- a/crates/bevy_editor_pls_default_windows/src/scenes.rs
+++ b/crates/bevy_editor_pls_default_windows/src/scenes.rs
@@ -4,6 +4,9 @@ use bevy_inspector_egui::egui::{self, RichText};
 
 const DEFAULT_FILENAME: &str = "scene.scn.ron";
 
+#[derive(Default, Component)]
+pub struct NotInScene;
+
 #[derive(Default)]
 pub struct SceneWindowState {
     filename: String,
@@ -37,7 +40,9 @@ impl EditorWindow for SceneWindow {
                 } else {
                     &state.filename
                 };
-                state.scene_save_result = Some(save_world(world, filename));
+                let mut query = world.query_filtered::<Entity, Without<NotInScene>>();
+                let entitys = query.iter(world).collect();
+                state.scene_save_result = Some(save_world(world, filename, entitys));
             }
         });
 
@@ -54,12 +59,56 @@ impl EditorWindow for SceneWindow {
     }
 }
 
-fn save_world(world: &World, name: &str) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+fn save_world(world: &World, name: &str, entitys: std::collections::HashSet<Entity>) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let type_registry = world.get_resource::<TypeRegistry>().unwrap();
-    let scene = DynamicScene::from_world(&world, type_registry);
+    let scene = from_world(&world, type_registry, entitys);
 
     let ron = scene.serialize_ron(type_registry)?;
     std::fs::write(name, ron)?;
 
     Ok(())
+}
+
+/// Create a new dynamic scene from a given world and etity set;
+fn from_world(world: &World, type_registry: &TypeRegistry, entitys: std::collections::HashSet<Entity>) -> DynamicScene {
+    use bevy::scene::DynamicEntity;
+    let mut scene = DynamicScene::default();
+    let type_registry = type_registry.read();
+
+    for archetype in world.archetypes().iter() {
+        // a map of an entity to its index in the dynamic scene;
+        // can't use simple offset like bevy's because it may skip an entity
+        let mut entity_map = std::collections::HashMap::new();
+        // Create a new dynamic entity for each entity of the given archetype
+        // and insert it into the dynamic scene.
+        // skip entitys not in the set
+        for entity in archetype.entities() {
+            if !entitys.contains(entity) {continue;}
+            entity_map.insert(entity, scene.entities.len());
+            scene.entities.push(DynamicEntity {
+                entity: entity.id(),
+                components: Vec::new(),
+            });
+        }
+
+        // Add each reflection-powered component to the entity it belongs to.
+        for component_id in archetype.components() {
+            let reflect_component = world
+                .components()
+                .get_info(component_id)
+                .and_then(|info| type_registry.get(info.type_id().unwrap()))
+                .and_then(|registration| registration.data::<ReflectComponent>());
+            if let Some(reflect_component) = reflect_component {
+                for entity in archetype.entities() {
+                    if !entitys.contains(entity) {continue;}
+                    if let Some(component) = reflect_component.reflect(world, *entity) {
+                        scene.entities[*entity_map.get(entity).expect("entity to have been added to map")]
+                            .components
+                            .push(component.clone_value());
+                    }
+                }
+            }
+        }
+    }
+    scene
 }


### PR DESCRIPTION
I am making a youtube video about scenes and wanted to include a section about using this plugin as a good way to set up and save scenes.
while making the video I built a system that let you save a scene without capturing things that are only used for setting up the scene such as cameras so I thought I might contribute back to your plugin by adding this functionality.

this adds a component that is on the editor cameras and can be added to any of the user's entities so they get skipped in the dynamic scene creation process.
this can also be done at runtime using the add context menu for extra UX