### PR TITLE
Fixes minor issues with the new Bevy scheduler's handling of exclusive systems

### DIFF
--- a/crates/bevy_editor_pls_core/src/editor.rs
+++ b/crates/bevy_editor_pls_core/src/editor.rs
@@ -28,7 +28,7 @@ impl Plugin for EditorPlugin {
             .add_event::<EditorEvent>()
             .add_system_to_stage(
                 CoreStage::PostUpdate,
-                Editor::system.before(EguiSystem::ProcessOutput),
+                Editor::system.at_start().label(EguiSystem::ProcessOutput),
             );
     }
 }

--- a/crates/bevy_editor_pls_default_windows/src/debug_settings/fake_time.rs
+++ b/crates/bevy_editor_pls_default_windows/src/debug_settings/fake_time.rs
@@ -8,7 +8,7 @@ use super::DebugSettingsWindow;
 pub fn setup(app: &mut App) {
     app.init_resource::<EditorTime>()
         .init_resource::<StashedTime>()
-        .add_system_to_stage(CoreStage::First, pause_time.after(TimeSystem));
+        .add_system_to_stage(CoreStage::First, pause_time);
 
     use_editor_time_for_egui(app);
 }


### PR DESCRIPTION
TLDR thanks to Bevy discord, all exclusive systems now run before all non-exclusive systems in a given stage, so a few of these scheduler orderings needed slight changes.

Note that the editor.rs change forces the Editor system to also become exclusive, otherwise it couldn't execute before ProcessOutput!  I think this does not really matter whatsoever though since this is a dev tool!