### PR TITLE
Re-add viewport updating for cameras. Use clip rect of Ui for viewport

### DIFF
--- a/crates/bevy_editor_pls_core/src/editor.rs
+++ b/crates/bevy_editor_pls_core/src/editor.rs
@@ -469,6 +469,7 @@ impl Editor {
                 window_states: &mut self.window_states,
                 internal_state,
             };
+
             (window.viewport_toolbar_ui_fn)(world, cx, ui);
         }
     }
@@ -486,9 +487,7 @@ impl egui_dock::TabViewer for TabViewer<'_> {
     fn ui(&mut self, ui: &mut egui::Ui, tab: &mut Self::Tab) {
         match *tab {
             TreeTab::GameView => {
-                // self.editor
-                // .editor_viewport_ui(self.world, ui, self.internal_state);
-
+                let viewport = ui.clip_rect();
                 ui.horizontal(|ui| {
                     ui.style_mut().spacing.button_padding = egui::vec2(2.0, 0.0);
                     let height = ui.spacing().interact_size.y;
@@ -498,8 +497,6 @@ impl egui_dock::TabViewer for TabViewer<'_> {
                         .editor_viewport_ui(self.world, ui, self.internal_state);
                 });
 
-                let (viewport, _) =
-                    ui.allocate_exact_size(ui.available_size(), egui::Sense::hover());
                 self.editor_state.viewport = viewport;
             }
             TreeTab::CustomWindow(window_id) => {

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -129,10 +129,10 @@ impl EditorWindow for CameraWindow {
             .add_system(initial_camera_setup);
         app.add_startup_system_to_stage(StartupStage::PreStartup, spawn_editor_cameras);
 
-        /*app.add_system_to_stage(
+        app.add_system_to_stage(
             CoreStage::PostUpdate,
             set_main_pass_viewport.before(bevy::render::camera::CameraUpdateSystem),
-        );*/
+        );
     }
 }
 
@@ -538,7 +538,7 @@ fn initial_camera_setup(
     }
 }
 
-/*fn set_main_pass_viewport(
+fn set_main_pass_viewport(
     editor_state: Res<bevy_editor_pls_core::EditorState>,
     egui_settings: Res<bevy_inspector_egui::bevy_egui::EguiSettings>,
     windows: Res<Windows>,
@@ -563,4 +563,4 @@ fn initial_camera_setup(
             depth: 0.0..1.0,
         });
     });
-}*/
+}


### PR DESCRIPTION
This fixes an issue where bevy_mod_picking will go through the egui, although it is a bit of a workaround. However this is also probably just beneficial anyways since we render less. 