### PR TITLE
Update bevy mod picking, only pick on primary click

### DIFF
--- a/crates/bevy_editor_pls_default_windows/Cargo.toml
+++ b/crates/bevy_editor_pls_default_windows/Cargo.toml
@@ -17,7 +17,7 @@ bevy = { version = "0.9", default-features = false, features = [
 ] }
 bevy_editor_pls_core = { version = "0.2", path = "../bevy_editor_pls_core" }
 bevy-inspector-egui = { version = "0.17", default-features = false }
-bevy_mod_picking = { git = "https://github.com/aevyrie/bevy_mod_picking", rev = "73a71c24814bbe78fb564277c8246decbabe60df", default-features = false, features = [
+bevy_mod_picking = { git = "https://github.com/aevyrie/bevy_mod_picking", rev = "7a9ffd020b530acef25c8cf8bc9475b7a13bd353", default-features = false, features = [
     "backend_raycast",
     "backend_egui",
     "backend_sprite",

--- a/crates/bevy_editor_pls_default_windows/src/hierarchy/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/hierarchy/mod.rs
@@ -17,7 +17,6 @@ use bevy_editor_pls_core::{
 };
 use bevy_mod_picking::backends::egui::EguiPointer;
 use bevy_mod_picking::prelude::{IsPointerEvent, PointerClick, PointerButton};
-use bevy_mod_picking::output::PointerDrag;
 
 use crate::add::{add_ui, AddWindow, AddWindowState};
 use crate::debug_settings::DebugSettingsWindow;
@@ -66,7 +65,6 @@ fn clear_removed_entites(mut editor: ResMut<Editor>, entities: &Entities) {
 
 fn handle_events(
     mut click_events: EventReader<PointerClick>,
-    mut drag_events: EventReader<PointerDrag>,
     mut editor: ResMut<Editor>,
     editor_state: Res<EditorState>,
     input: Res<Input<KeyCode>>,

--- a/crates/bevy_editor_pls_default_windows/src/hierarchy/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/hierarchy/mod.rs
@@ -16,7 +16,8 @@ use bevy_editor_pls_core::{
     Editor,
 };
 use bevy_mod_picking::backends::egui::EguiPointer;
-use bevy_mod_picking::prelude::{IsPointerEvent, PointerClick};
+use bevy_mod_picking::prelude::{IsPointerEvent, PointerClick, PointerButton};
+use bevy_mod_picking::output::PointerDrag;
 
 use crate::add::{add_ui, AddWindow, AddWindowState};
 use crate::debug_settings::DebugSettingsWindow;
@@ -65,6 +66,7 @@ fn clear_removed_entites(mut editor: ResMut<Editor>, entities: &Entities) {
 
 fn handle_events(
     mut click_events: EventReader<PointerClick>,
+    mut drag_events: EventReader<PointerDrag>,
     mut editor: ResMut<Editor>,
     editor_state: Res<EditorState>,
     input: Res<Input<KeyCode>>,
@@ -75,6 +77,11 @@ fn handle_events(
         if !editor_state.active {
             return;
         }
+
+        if click.event_data().button != PointerButton::Primary {
+            continue;
+        }
+
         if egui_entity.get(click.target()).is_ok() || egui_ctx.ctx_mut().wants_pointer_input() {
             continue;
         };


### PR DESCRIPTION
Currently rotating the camera with right click with select an entity which is counter intuitive