### PR TITLE
fix missing tab bar background

### DIFF
--- a/crates/bevy_editor_pls_core/src/editor.rs
+++ b/crates/bevy_editor_pls_core/src/editor.rs
@@ -302,15 +302,21 @@ impl Editor {
             &mut internal_state.tree,
             egui_dock::Tree::new(Vec::default()),
         );
-        egui_dock::DockArea::new(&mut tree).show(
-            ctx,
-            &mut TabViewer {
-                editor: self,
-                internal_state,
-                world,
-                editor_state,
-            },
-        );
+
+        egui_dock::DockArea::new(&mut tree)
+            .style(egui_dock::Style {
+                tab_bar_background_color: ctx.style().visuals.window_fill(),
+                ..egui_dock::Style::from_egui(ctx.style().as_ref())
+            })
+            .show(
+                ctx,
+                &mut TabViewer {
+                    editor: self,
+                    internal_state,
+                    world,
+                    editor_state,
+                },
+            );
         internal_state.tree = tree;
 
         let pointer_pos = ctx.input(|input| input.pointer.interact_pos());


### PR DESCRIPTION
This fixes the issue I encountered after the viewport transparency was fixed in egui_dock 0.4.2, see #68

egui_dock uses a very transparent color as a default for tab bar background. Luckily it was configurable. This PR customizes the Style to use the same color as the rest of the panels/tabs.