### PR TITLE
Update to Bevy 0.11 (temporary dependencies)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ bevy_editor_pls = { version = "0.4.0", path = "crates/bevy_editor_pls" }
 bevy_editor_pls_core = { version = "0.4.0", path = "crates/bevy_editor_pls_core" }
 bevy_editor_pls_default_windows = { version = "0.4.0", path = "crates/bevy_editor_pls_default_windows" }
 
-bevy-inspector-egui = "0.18"
-egui = "0.21"
+bevy-inspector-egui = { git = "https://github.com/KMaheshBhat/bevy-inspector-egui.git", branch = "feature/bevy_0.11_upgrade" }
+egui = "0.22"
 
 [profile.dev.package."*"]
 opt-level = 2

--- a/crates/bevy_editor_pls/Cargo.toml
+++ b/crates/bevy_editor_pls/Cargo.toml
@@ -18,14 +18,14 @@ default = ["default_windows"]
 [dependencies]
 bevy_editor_pls_core.workspace = true
 bevy_editor_pls_default_windows = { workspace = true, optional = true }
-bevy = { version = "0.10", default-features = false, features = ["x11"] }
+bevy = { version = "0.11", default-features = false, features = ["x11"] }
 egui.workspace = true
-egui-gizmo = "0.10.0"
-bevy_framepace = "0.12.0"
+egui-gizmo = "0.11.0"
+bevy_framepace = { git = "https://github.com/AlexAegis/bevy_framepace" }
 # bevy_framepace = { version = "0.11", default-features = false }
 
 [dev-dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
     "bevy_winit",
     "bevy_core_pipeline",
     "x11",

--- a/crates/bevy_editor_pls/src/controls.rs
+++ b/crates/bevy_editor_pls/src/controls.rs
@@ -279,7 +279,7 @@ impl EditorControls {
             Action::PauseUnpauseTime,
             Binding {
                 input: UserInput::Chord(vec![
-                    Button::Keyboard(KeyCode::LControl),
+                    Button::Keyboard(KeyCode::ControlLeft),
                     Button::Keyboard(KeyCode::Return),
                 ]),
                 conditions: vec![BindingCondition::ListeningForText(false)],

--- a/crates/bevy_editor_pls/src/lib.rs
+++ b/crates/bevy_editor_pls/src/lib.rs
@@ -3,7 +3,7 @@
 pub mod controls;
 
 use bevy::{
-    prelude::{Entity, Plugin},
+    prelude::{Entity, Plugin, Update},
     window::{MonitorSelection, Window, WindowPosition, WindowRef, WindowResolution},
 };
 
@@ -90,11 +90,11 @@ impl Plugin for EditorPlugin {
             EditorWindowPlacement::Primary => WindowRef::Primary,
         };
 
-        app.add_plugin(bevy_editor_pls_core::EditorPlugin { window });
+        app.add_plugins(bevy_editor_pls_core::EditorPlugin { window });
 
         if !app.is_plugin_added::<bevy_framepace::FramepacePlugin>() {
-            app.add_plugin(bevy_framepace::FramepacePlugin);
-            app.add_plugin(bevy_framepace::debug::DiagnosticsPlugin);
+            app.add_plugins(bevy_framepace::FramepacePlugin);
+            app.add_plugins(bevy_framepace::debug::DiagnosticsPlugin);
         }
 
         #[cfg(feature = "default_windows")]
@@ -124,10 +124,10 @@ impl Plugin for EditorPlugin {
             app.add_editor_window::<GizmoWindow>();
             app.add_editor_window::<controls::ControlsWindow>();
 
-            app.add_plugin(bevy::pbr::wireframe::WireframePlugin);
+            app.add_plugins(bevy::pbr::wireframe::WireframePlugin);
 
             app.insert_resource(controls::EditorControls::default_bindings())
-                .add_system(controls::editor_controls_system);
+                .add_systems(Update, controls::editor_controls_system);
 
             let mut internal_state = app.world.resource_mut::<editor::EditorInternalState>();
 

--- a/crates/bevy_editor_pls_core/Cargo.toml
+++ b/crates/bevy_editor_pls_core/Cargo.toml
@@ -8,7 +8,7 @@ description.workspace = true
 readme.workspace = true
 
 [dependencies]
-bevy = { version = "0.10", default-features = false }
+bevy = { version = "0.11", default-features = false }
 bevy-inspector-egui.workspace = true
 indexmap = "1.7"
-egui_dock = "0.4"
+egui_dock = "0.6"

--- a/crates/bevy_editor_pls_core/src/editor.rs
+++ b/crates/bevy_editor_pls_core/src/editor.rs
@@ -4,12 +4,13 @@ use bevy::ecs::event::Events;
 use bevy::window::WindowMode;
 use bevy::{prelude::*, utils::HashMap};
 use bevy_inspector_egui::bevy_egui::{egui, EguiContext};
-use egui_dock::{NodeIndex, TabIndex};
+use egui_dock::{NodeIndex, TabIndex, TabBarStyle};
 use indexmap::IndexMap;
 
 use crate::editor_window::{EditorWindow, EditorWindowContext};
 
 #[non_exhaustive]
+#[derive(Event)]
 pub enum EditorEvent {
     Toggle { now_active: bool },
     FocusSelected,
@@ -314,7 +315,10 @@ impl Editor {
 
         egui_dock::DockArea::new(&mut tree)
             .style(egui_dock::Style {
-                tab_bar_background_color: ctx.style().visuals.window_fill(),
+                tab_bar: TabBarStyle {
+                    bg_fill: ctx.style().visuals.window_fill(),
+                    ..default()
+                },
                 ..egui_dock::Style::from_egui(ctx.style().as_ref())
             })
             .show(

--- a/crates/bevy_editor_pls_core/src/lib.rs
+++ b/crates/bevy_editor_pls_core/src/lib.rs
@@ -45,10 +45,10 @@ pub struct EditorPlugin {
 impl Plugin for EditorPlugin {
     fn build(&self, app: &mut App) {
         if !app.is_plugin_added::<DefaultInspectorConfigPlugin>() {
-            app.add_plugin(DefaultInspectorConfigPlugin);
+            app.add_plugins(DefaultInspectorConfigPlugin);
         }
         if !app.is_plugin_added::<EguiPlugin>() {
-            app.add_plugin(EguiPlugin);
+            app.add_plugins(EguiPlugin);
         }
 
         let (window_entity, always_active) = match self.window {
@@ -65,13 +65,11 @@ impl Plugin for EditorPlugin {
         app.insert_resource(Editor::new(window_entity, always_active))
             .init_resource::<EditorInternalState>()
             .add_event::<EditorEvent>()
-            .configure_set(EditorSet::UI.in_base_set(CoreSet::PostUpdate))
-            .add_system(
-                Editor::system
-                    .in_set(EditorSet::UI)
-                    .before(TransformSystem::TransformPropagate)
-                    .before(CameraUpdateSystem)
-                    .before(EguiSet::ProcessOutput),
+            .configure_set(PostUpdate, EditorSet::UI)
+            .add_systems(Update,
+                Editor::system.in_set(EditorSet::UI).before(TransformSystem::TransformPropagate)
+                .before(CameraUpdateSystem)
+                .before(EguiSet::ProcessOutput),
             );
     }
 }

--- a/crates/bevy_editor_pls_default_windows/Cargo.toml
+++ b/crates/bevy_editor_pls_default_windows/Cargo.toml
@@ -11,7 +11,7 @@ readme.workspace = true
 highlight_changes = ["bevy-inspector-egui/highlight_changes"]
 
 [dependencies]
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
     "bevy_scene",
     "bevy_text",
     "bevy_ui",
@@ -29,6 +29,6 @@ bevy-inspector-egui.workspace = true
 # ] }
 indexmap = "1.7"
 pretty-type-name = "1.0"
-bevy_mod_debugdump = "0.7"
+bevy_mod_debugdump = { git = "https://github.com/Olle-Lukowski/bevy_mod_debugdump" }
 opener = "0.5.0"
-egui-gizmo = "0.10.0"
+egui-gizmo = "0.11.0"

--- a/crates/bevy_editor_pls_default_windows/src/cameras/camera_2d_panzoom.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/camera_2d_panzoom.rs
@@ -17,8 +17,8 @@ pub(crate) struct PanCamPlugin;
 
 impl Plugin for PanCamPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(camera_movement.in_set(CameraSystem::Movement))
-            .add_system(camera_zoom.in_set(CameraSystem::Movement));
+        app.add_systems(Update, camera_movement.in_set(CameraSystem::Movement))
+            .add_systems(Update, camera_zoom.in_set(CameraSystem::Movement));
     }
 }
 

--- a/crates/bevy_editor_pls_default_windows/src/cameras/camera_3d_free.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/camera_3d_free.rs
@@ -3,8 +3,8 @@ use bevy::{input::mouse::MouseMotion, prelude::*};
 pub(crate) struct FlycamPlugin;
 impl Plugin for FlycamPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(camera_movement.in_set(CameraSystem::Movement))
-            .add_system(camera_look);
+        app.add_systems(Update, camera_movement.in_set(CameraSystem::Movement))
+            .add_systems(Update, camera_look);
     }
 }
 
@@ -42,8 +42,8 @@ impl Default for FlycamControls {
             key_left: KeyCode::A,
             key_right: KeyCode::D,
             key_up: KeyCode::Space,
-            key_down: KeyCode::LControl,
-            key_boost: KeyCode::LShift,
+            key_down: KeyCode::ControlLeft,
+            key_boost: KeyCode::ShiftLeft,
         }
     }
 }

--- a/crates/bevy_editor_pls_default_windows/src/cameras/camera_3d_panorbit.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/camera_3d_panorbit.rs
@@ -10,7 +10,7 @@ use bevy_editor_pls_core::Editor;
 pub struct PanOrbitCameraPlugin;
 impl Plugin for PanOrbitCameraPlugin {
     fn build(&self, app: &mut App) {
-        app.add_system(pan_orbit_camera.in_set(CameraSystem::Movement));
+        app.add_systems(Update, pan_orbit_camera.in_set(CameraSystem::Movement));
     }
 }
 

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -117,23 +117,22 @@ impl EditorWindow for CameraWindow {
     fn app_setup(app: &mut App) {
         app.init_resource::<PreviouslyActiveCameras>();
 
-        app.add_plugin(camera_2d_panzoom::PanCamPlugin)
-            .add_plugin(camera_3d_free::FlycamPlugin)
-            .add_plugin(camera_3d_panorbit::PanOrbitCameraPlugin)
-            .add_system(
+        app.add_plugins(camera_2d_panzoom::PanCamPlugin)
+            .add_plugins(camera_3d_free::FlycamPlugin)
+            .add_plugins(camera_3d_panorbit::PanOrbitCameraPlugin)
+            .add_systems(Update,
                 set_editor_cam_active
                     .before(camera_3d_panorbit::CameraSystem::Movement)
                     .before(camera_3d_free::CameraSystem::Movement)
                     .before(camera_2d_panzoom::CameraSystem::Movement),
             )
-            .add_system(toggle_editor_cam.in_base_set(CoreSet::PreUpdate))
-            .add_system(focus_selected.in_base_set(CoreSet::PreUpdate))
-            .add_system(initial_camera_setup);
-        app.add_startup_system(spawn_editor_cameras.in_base_set(StartupSet::PreStartup));
+            .add_systems(PreUpdate, toggle_editor_cam)
+            .add_systems(PreUpdate, focus_selected)
+            .add_systems(Update, initial_camera_setup);
+        app.add_systems(PreStartup, spawn_editor_cameras);
 
-        app.add_system(
+        app.add_systems(PostUpdate,
             set_main_pass_viewport
-                .in_base_set(CoreSet::PostUpdate)
                 .after(bevy_editor_pls_core::EditorSet::UI)
                 .before(bevy::render::camera::CameraUpdateSystem),
         );

--- a/crates/bevy_editor_pls_default_windows/src/debug_settings/debugdump.rs
+++ b/crates/bevy_editor_pls_default_windows/src/debug_settings/debugdump.rs
@@ -34,27 +34,24 @@ pub fn setup(app: &mut App) {
     };
     let rendergraph_settings = render_graph::settings::Settings::default();
 
-    let main_schedule = schedule_graph::schedule_graph_dot(
-        app.get_schedule(Main).unwrap(),
-        &app.world,
-        &schedule_settings,
-    );
-    let fixed_update_schedule = schedule_graph::schedule_graph_dot(
-        app.get_schedule(FixedUpdate).unwrap(),
-        &app.world,
-        &schedule_settings,
-    );
+    let main_schedule = match app.get_schedule(Main) {
+        Some(schedule) => schedule_graph::schedule_graph_dot(schedule, &app.world, &schedule_settings),
+        None => "".to_string(),
+    };
+    
+    let fixed_update_schedule = match app.get_schedule(FixedUpdate) {
+        Some(schedule) => schedule_graph::schedule_graph_dot(schedule, &app.world, &schedule_settings),
+        None => "".to_string(),
+    };
 
-    let render_main_schedule = schedule_graph::schedule_graph_dot(
-        render_app.get_schedule(Main).unwrap(),
-        &app.world,
-        &schedule_settings,
-    );
-    let render_extract_schedule = schedule_graph::schedule_graph_dot(
-        render_app.get_schedule(ExtractSchedule).unwrap(),
-        &app.world,
-        &schedule_settings,
-    );
+    let render_main_schedule = match render_app.get_schedule(FixedUpdate) {
+        Some(schedule) => schedule_graph::schedule_graph_dot(schedule, &app.world, &schedule_settings),
+        None => "".to_string(),
+    };
+    let render_extract_schedule = match render_app.get_schedule(ExtractSchedule) {
+        Some(schedule) => schedule_graph::schedule_graph_dot(schedule, &app.world, &schedule_settings),
+        None => "".to_string(),
+    };
 
     let render_graph = render_graph::render_graph_dot(render_graph, &rendergraph_settings);
 

--- a/crates/bevy_editor_pls_default_windows/src/debug_settings/debugdump.rs
+++ b/crates/bevy_editor_pls_default_windows/src/debug_settings/debugdump.rs
@@ -35,18 +35,18 @@ pub fn setup(app: &mut App) {
     let rendergraph_settings = render_graph::settings::Settings::default();
 
     let main_schedule = schedule_graph::schedule_graph_dot(
-        app.get_schedule(CoreSchedule::Main).unwrap(),
+        app.get_schedule(Main).unwrap(),
         &app.world,
         &schedule_settings,
     );
     let fixed_update_schedule = schedule_graph::schedule_graph_dot(
-        app.get_schedule(CoreSchedule::FixedUpdate).unwrap(),
+        app.get_schedule(FixedUpdate).unwrap(),
         &app.world,
         &schedule_settings,
     );
 
     let render_main_schedule = schedule_graph::schedule_graph_dot(
-        render_app.get_schedule(CoreSchedule::Main).unwrap(),
+        render_app.get_schedule(Main).unwrap(),
         &app.world,
         &schedule_settings,
     );

--- a/crates/bevy_editor_pls_default_windows/src/diagnostics.rs
+++ b/crates/bevy_editor_pls_default_windows/src/diagnostics.rs
@@ -1,4 +1,4 @@
-use bevy::{diagnostic::Diagnostics, prelude::*};
+use bevy::{diagnostic::DiagnosticsStore, prelude::*};
 use bevy_editor_pls_core::editor_window::{EditorWindow, EditorWindowContext};
 use bevy_inspector_egui::egui;
 
@@ -8,7 +8,7 @@ impl EditorWindow for DiagnosticsWindow {
     const NAME: &'static str = "Diagnostics";
 
     fn ui(world: &mut World, _cx: EditorWindowContext, ui: &mut egui::Ui) {
-        let diagnostics = match world.get_resource::<Diagnostics>() {
+        let diagnostics = match world.get_resource::<DiagnosticsStore>() {
             Some(diagnostics) => diagnostics,
             None => {
                 ui.label("Diagnostics resource not available");
@@ -19,7 +19,7 @@ impl EditorWindow for DiagnosticsWindow {
     }
 }
 
-fn diagnostic_ui(ui: &mut egui::Ui, diagnostics: &Diagnostics) {
+fn diagnostic_ui(ui: &mut egui::Ui, diagnostics: &DiagnosticsStore) {
     egui::Grid::new("frame time diagnostics").show(ui, |ui| {
         let mut has_diagnostics = false;
         for diagnostic in diagnostics.iter() {

--- a/crates/bevy_editor_pls_default_windows/src/gizmos.rs
+++ b/crates/bevy_editor_pls_default_windows/src/gizmos.rs
@@ -86,7 +86,7 @@ impl EditorWindow for GizmoWindow {
             camera_material: material_camera,
         });
 
-        app.add_system(add_gizmo_markers.in_base_set(CoreSet::PostUpdate));
+        app.add_systems(PostUpdate, add_gizmo_markers);
     }
 }
 

--- a/crates/bevy_editor_pls_default_windows/src/hierarchy/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/hierarchy/mod.rs
@@ -61,11 +61,11 @@ impl EditorWindow for HierarchyWindow {
 
     fn app_setup(app: &mut bevy::prelude::App) {
         // picking::setup(app);
-        app.add_system(clear_removed_entites.in_base_set(CoreSet::PostUpdate));
+        app.add_systems(PostUpdate, clear_removed_entites);
         // .add_system(handle_events);
 
         app.sub_app_mut(RenderApp)
-            .add_system(extract_wireframe_for_selected.in_schedule(ExtractSchedule));
+            .add_systems(ExtractSchedule, extract_wireframe_for_selected);
     }
 }
 

--- a/crates/bevy_editor_pls_default_windows/src/scenes.rs
+++ b/crates/bevy_editor_pls_default_windows/src/scenes.rs
@@ -66,7 +66,7 @@ fn save_world(
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let type_registry = world.get_resource::<AppTypeRegistry>().unwrap();
     let mut scene_builder =
-        DynamicSceneBuilder::from_world_with_type_registry(world, type_registry.clone());
+        DynamicSceneBuilder::from_world(world);
     scene_builder.extract_entities(entities.into_iter());
     let scene = scene_builder.build();
 


### PR DESCRIPTION
I have updated the crate to use bevy 0.11, this currently requires us a couple unmerged pull requests in bevy_inspector_egui, bevy_framepace and bevy_mod_debugdump. This is not intended for merge because the dependencies are not merged into their main repo yet, but I just wanted to have this here for anyone who wants to use bevy_editor_pls with the latest version of bevy!