### PR TITLE
Fixed Mouse Control Glitches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 0.7.1
+- fix mouse control glitches introduced in version 0.6
+
 ## Version 0.7
 - update to `bevy-inspector-egui` 0.22 and `egui` 0.24
 

--- a/crates/bevy_editor_pls_default_windows/src/cameras/camera_3d_free.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/camera_3d_free.rs
@@ -94,10 +94,9 @@ fn camera_look(
     mut query: Query<(&mut FlycamControls, &mut Transform)>,
 ) {
     let (mut flycam, mut transform) = query.single_mut();
-    if !mouse_input.pressed(MouseButton::Right) {
-        return;
-    }
-    if !flycam.enable_look {
+    if !flycam.enable_look || !mouse_input.pressed(MouseButton::Right) {
+        //Prevent accumulation of irrelevant events
+        mouse_motion_event_reader.clear();
         return;
     }
     let mut delta: Vec2 = Vec2::ZERO;

--- a/crates/bevy_editor_pls_default_windows/src/cameras/camera_3d_panorbit.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/camera_3d_panorbit.rs
@@ -61,6 +61,9 @@ fn pan_orbit_camera(
     mut query: Query<(&mut PanOrbitCamera, &mut Transform, &Projection)>,
 ) {
     let Ok(window) = window.get(editor.window()) else {
+        //Prevent accumulation of irrelevant events
+        ev_motion.clear();
+        ev_scroll.clear();
         return;
     };
 
@@ -68,6 +71,9 @@ fn pan_orbit_camera(
     let (mut pan_orbit, mut transform, projection) = query.single_mut();
 
     if !pan_orbit.enabled {
+        //Prevent accumulation of irrelevant events
+        ev_motion.clear();
+        ev_scroll.clear();
         return;
     }
 
@@ -86,6 +92,11 @@ fn pan_orbit_camera(
             pan += ev.delta;
         }
     }
+    else {
+        //Prevent accumulation of irrelevant events
+        ev_motion.clear();
+    }
+
     for ev in ev_scroll.read() {
         scroll += ev.y;
     }

--- a/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
+++ b/crates/bevy_editor_pls_default_windows/src/cameras/mod.rs
@@ -342,6 +342,8 @@ fn toggle_editor_cam(
     mut cam_query: Query<(Entity, &mut Camera)>,
 ) {
     if editor.always_active() {
+        //Prevent accumulation of irrelevant events
+        editor_events.clear();
         return;
     }
 
@@ -388,6 +390,8 @@ fn focus_selected(
     window: Query<&Window>,
 ) {
     let Ok(window) = window.get(editor.window()) else {
+        //Prevent accumulation of irrelevant events
+        editor_events.clear();
         return;
     };
 


### PR DESCRIPTION
As of Bevy 0.12, EventReader buffers are no longer cleared between frames, causing the accumulation of non-consumed events.

In the case of systems that ignore events conditionally (like if a button is not pressed down), then unless you clear the buffer, all of those events will be replayed the next time the user presses the button, causing erratic behaviour.

For bevy_editor_pls, the consequence of not clearing the buffers is that if you move the mouse in between different pans/orbits/scrolling, the camera jerks erratically as soon as you press the button. The further it moved when the button wasn't pressed, the worse the effect.

I fixed this by clearing the buffers at any time that a system would return prior to the buffer being read. I audited non-mouse EventReaders as well; in those cases the consequences were likely just wasted memory, but I figured that I ought to fix all of them at once.

See also: https://github.com/bevyengine/bevy/issues/10860