### PR TITLE
bump bevy-inspector-egui

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jakobhellermann/bevy_editor_pls"
@@ -11,11 +11,11 @@ description = "In-App editor tools for bevy apps"
 readme = "README.md"
 
 [workspace.dependencies]
-bevy_editor_pls = { version = "0.9.0", path = "crates/bevy_editor_pls" }
-bevy_editor_pls_core = { version = "0.9.0", path = "crates/bevy_editor_pls_core" }
-bevy_editor_pls_default_windows = { version = "0.9.0", path = "crates/bevy_editor_pls_default_windows" }
+bevy_editor_pls = { version = "0.10.0", path = "crates/bevy_editor_pls" }
+bevy_editor_pls_core = { version = "0.10.0", path = "crates/bevy_editor_pls_core" }
+bevy_editor_pls_default_windows = { version = "0.10.0", path = "crates/bevy_editor_pls_default_windows" }
 
-bevy-inspector-egui = "0.25.0"
+bevy-inspector-egui = "0.26.0"
 egui = "0.28"
 egui_dock = "0.13"
 # used to be egui-gizmo 0.16


### PR DESCRIPTION
The upstream `bevy_egui` is now at `0.29`, where `bevy_inspector_egui` had just recently released version `0.26.0` to account for that (https://github.com/jakobhellermann/bevy-inspector-egui/commit/a9ecb3aebf7bbb97751cdc6a96b5477017d02eb3).

There were some breaking changes and without upgrading the indirect dependency of  `bevy_egui` to `0.29`, I'm getting

```rust
Resource requested by ......::debug_ui does not exist: bevy_egui::EguiUserTextures
```
even after adding the `bevy_editor_pls` plugin. (manually adding `EguiPlugin` will results in error saying plugin already added instead).

Bumping the version fixes it.