### PR TITLE
sync versions for current bevy 0.14.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bevy_editor_pls = { version = "0.9.0", path = "crates/bevy_editor_pls" }
 bevy_editor_pls_core = { version = "0.9.0", path = "crates/bevy_editor_pls_core" }
 bevy_editor_pls_default_windows = { version = "0.9.0", path = "crates/bevy_editor_pls_default_windows" }
 
-bevy-inspector-egui = "0.25.0"
+bevy-inspector-egui = "0.26.0"
 egui = "0.28"
 egui_dock = "0.13"
 # used to be egui-gizmo 0.16


### PR DESCRIPTION
The current bevy (0.14.2) depends on bevy_egui 0.29. But this crate is behind in dependencies.
This will fix runtime crashes for "resource requested by * does not exist: bevy_egui::EguiUserTextures) and sync up denendencies