### PR TITLE
Standalone function to trigger floating window

### DIFF
--- a/crates/bevy_editor_pls_core/src/editor_window.rs
+++ b/crates/bevy_editor_pls_core/src/editor_window.rs
@@ -97,14 +97,20 @@ impl EditorWindowContext<'_> {
     }
 
     pub fn open_floating_window<W: ?Sized + EditorWindow>(&mut self) {
-        let floating_window_id = self.internal_state.next_floating_window_id();
-        let window_id = std::any::TypeId::of::<W>();
-        self.internal_state
-            .floating_windows
-            .push(crate::editor::FloatingWindow {
-                window: window_id,
-                id: floating_window_id,
-                initial_position: None,
-            });
+        open_floating_window::<W>(self.internal_state)
     }
+}
+
+pub fn open_floating_window<W: ?Sized + EditorWindow>(
+    editor_internal_state: &mut crate::editor::EditorInternalState,
+) {
+    let floating_window_id = editor_internal_state.next_floating_window_id();
+    let window_id = std::any::TypeId::of::<W>();
+    editor_internal_state
+        .floating_windows
+        .push(crate::editor::FloatingWindow {
+            window: window_id,
+            id: floating_window_id,
+            initial_position: None,
+        });
 }


### PR DESCRIPTION
This simple refactor allows one to trigger floating window from other systems:
```rust
app.add_systems(Startup, start_window);
...

fn start_window(internal_state: ResMut<EditorInternalState>) {
  open_floating_window::<MyEditorWindow>(
    internal_state.into_inner()
  );
}
```

----

with this refactor, (I don't think) it's possible to start floating window from other system as `crate::editor::FloatingWindow { ... }` is a private struct.