### PR TITLE
Update to Rust 2024 and remove Cargo patch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 version = "0.11.0"
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/jakobhellermann/bevy_editor_pls"
 description = "In-App editor tools for bevy apps"
@@ -19,9 +19,6 @@ bevy-inspector-egui = "0.28.0"
 egui = "0.29"
 egui_dock = "0.14"
 transform-gizmo-bevy = "0.5"
-
-[patch.crates-io]
-transform-gizmo-bevy = { git = "https://github.com/ActuallyHappening/transform-gizmo" }
 
 [profile.dev.package."*"]
 opt-level = 2


### PR DESCRIPTION
`transform-gizmo-bevy` released 0.5 four days ago, so the patch is no longer needed.

Testing: `cargo test --doc` passed.